### PR TITLE
ci: let Renovate open @couch-kit PRs on any run

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["before 9am on monday"],
   "rangeStrategy": "bump",
   "packageRules": [
     {


### PR DESCRIPTION
Removes the `schedule: before 9am on monday` restriction from `renovate.json` so the first catch-up update (`@couch-kit/core` is already behind at 0.8.3 → 0.9.1) lands as soon as Renovate runs, rather than waiting until Monday. Grouping, @couch-kit scoping, and non-major auto-merge are unchanged.