### PR TITLE
ci: let Renovate open @couch-kit PRs without dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "rangeStrategy": "bump",
+  "dependencyDashboardApproval": false,
   "packageRules": [
     {
       "description": "This repo dogfoods couch-kit — only manage @couch-kit/* dependencies.",


### PR DESCRIPTION
Renovate has been holding the grouped `@couch-kit` update under **Pending Approval** on its dependency dashboard rather than opening a PR. Setting `dependencyDashboardApproval: false` makes it open (and auto-merge non-major) PRs automatically, no manual approval needed.