### PR TITLE
fix(build): use tsc -b so shared is built on fresh Vercel clones

### DIFF
--- a/packages/client/.gitignore
+++ b/packages/client/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/display/.gitignore
+++ b/packages/display/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Problem

The Vercel Git-integration builds for both `buzz-controller` (packages/client) and `buzz-display` (packages/display) failed on a fresh clone:

```
src/App.tsx(7,8): error TS6305: Output file '.../packages/shared/dist/index.d.ts'
  has not been built from source file '.../packages/shared/index.ts'.
```

`@my-game/shared` is a `composite: true` TS project whose `dist/` is gitignored. The app build script was `tsc && vite build`; plain `tsc` verifies referenced composite outputs exist but does not build them, so on Vercel's fresh clone (no local `dist/`) the typecheck step failed before Vite ever ran.

## Fix

Switch both apps to `tsc -b && vite build`. Build mode compiles referenced composite projects (`../shared`) first, emitting `shared/dist`, then typechecks the app. Verified locally from a clean state (`rm -rf packages/*/dist`) — both apps build green.

Also commits the Vercel CLI `.gitignore` files (`.vercel`, `.env*`) that project linking created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)