### PR TITLE
feat: move relay to Cloudflare Workers + Durable Objects

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
       "name": "@my-game/client",
       "version": "1.0.0",
       "dependencies": {
-        "@couch-kit/client": "^0.9.0",
+        "@couch-kit/client": "^0.10.0",
         "@my-game/shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -31,7 +31,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@couch-kit/core": "^0.9.3",
-        "@couch-kit/display": "^0.1.1",
+        "@couch-kit/display": "^0.2.0",
         "@my-game/shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -272,13 +272,13 @@
 
     "@couch-kit/cli": ["@couch-kit/cli@0.3.9", "", { "dependencies": { "@couch-kit/core": "0.9.3", "commander": "^15.0.0" }, "bin": { "couch-kit": "dist/index.js" } }, "sha512-LFbLGxE5QIf4TT6xkCJUrIiw7/AVeuFE0QABFBPqdrl1sQZrDaeOme4lCciGytYMqBP3dlE4KEXieqnyZ1LXzA=="],
 
-    "@couch-kit/client": ["@couch-kit/client@0.9.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-IOXSke9hl1YVW1p94+biYnwEJKGC+5JmRnHgFlx8Jhi7cbIB4CQmjQs69jG6QgOiBCHSfM36LnUT71EAS2+LjA=="],
+    "@couch-kit/client": ["@couch-kit/client@0.10.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-hlvL06gGlZXrv3Dc+IeobgERJY9kNzeq/+eH0QfF+JeeNu7iLiN8lYsuZuv2Q8wuSNDFkDgkVKesyjd1ENb1QA=="],
 
     "@couch-kit/core": ["@couch-kit/core@0.9.3", "", {}, "sha512-8qo0goKd1FkACnWWZCsGHFZWeQqnz3uQgUgKaCoKOXf0AJ1fjF/EJSGAYrHNwPGtKy6Br6CUeJBCzULyQFxFYg=="],
 
     "@couch-kit/devtools": ["@couch-kit/devtools@1.0.0", "", { "peerDependencies": { "@couch-kit/client": "0.9.0", "react": ">=18.0.0" } }, "sha512-whYUy3Ntl0cgYJgD0y5CG+Y5RNJn/JdS6Ta9Rw5yGtlBp5cz71P+Gitjs4Vu7dvx751cePtLWlCbrVadsPU+xw=="],
 
-    "@couch-kit/display": ["@couch-kit/display@0.1.1", "", { "dependencies": { "@couch-kit/client": "0.9.0", "@couch-kit/core": "0.9.3", "@couch-kit/runtime": "0.1.0" } }, "sha512-+lnM0BpM9zingVr7HRZ2iRu5rNxIAlZXHOU2FRtdptMecqOnezNh1lkhSFtU97Qt9N6ZHyMc6zxB20cqGimwpA=="],
+    "@couch-kit/display": ["@couch-kit/display@0.2.0", "", { "dependencies": { "@couch-kit/client": "0.10.0", "@couch-kit/core": "0.9.3", "@couch-kit/runtime": "0.1.0" } }, "sha512-jpQOq8l57CIdqovsgB4uCqfG0c4Xr5az1IVZw0snwXNWeb6L8Ie8Q4yICRLZbuDHScX1NTTgHXS+Q72WeA7BbQ=="],
 
     "@couch-kit/host": ["@couch-kit/host@1.7.14", "", { "dependencies": { "@couch-kit/core": "0.9.3", "@couch-kit/runtime": "0.1.0", "buffer": "^6.0.3", "js-sha1": "^0.7.0", "react-native-nitro-http-server": "^1.6.1" }, "peerDependencies": { "expo": ">=51.0.0", "expo-file-system": ">=19.0.0", "expo-network": ">=7.0.0", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-nitro-modules": ">=0.33.0" } }, "sha512-YWzPKNmKLSR5GrbDC+qBhXqmFLpsgTkYMh5zebXkZR1UnBXp2o2RFGJ/AcKqG+Vccbs+VWWHXb5sO//5vUmONg=="],
 
@@ -1299,6 +1299,8 @@
     "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@couch-kit/devtools/@couch-kit/client": ["@couch-kit/client@0.9.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-IOXSke9hl1YVW1p94+biYnwEJKGC+5JmRnHgFlx8Jhi7cbIB4CQmjQs69jG6QgOiBCHSfM36LnUT71EAS2+LjA=="],
 
     "@couch-kit/host/expo-file-system": ["expo-file-system@19.0.21", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg=="],
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@couch-kit/client": "^0.9.0",
+    "@couch-kit/client": "^0.10.0",
     "@my-game/shared": "workspace:*"
   },
   "devDependencies": {

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -6,7 +6,7 @@ import { gameReducer, initialState } from "@my-game/shared";
 // VITE_RELAY_URL, or per-link with a `&relay=wss://...` query param.
 const DEFAULT_RELAY_URL =
   (import.meta.env.VITE_RELAY_URL as string | undefined) ??
-  "wss://couch-kit-relay.icycliff-4c194e2e.eastus.azurecontainerapps.io";
+  "wss://couch-kit-relay.faluciano.workers.dev";
 
 /**
  * Cross-network relay is **opt-in** via `?room=CODE` in the controller URL

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@couch-kit/core": "^0.9.3",
-    "@couch-kit/display": "^0.1.1",
+    "@couch-kit/display": "^0.2.0",
     "@my-game/shared": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/display/src/App.tsx
+++ b/packages/display/src/App.tsx
@@ -10,7 +10,7 @@ import { RelayDisplayHost } from "@couch-kit/display";
 
 const RELAY_URL =
   import.meta.env.VITE_RELAY_URL ??
-  "wss://couch-kit-relay.icycliff-4c194e2e.eastus.azurecontainerapps.io";
+  "wss://couch-kit-relay.faluciano.workers.dev";
 
 // Base URL of the deployed controller. The join link appends `?room=CODE`.
 const CONTROLLER_URL = import.meta.env.VITE_CONTROLLER_URL ?? "";


### PR DESCRIPTION
Switches this game from the Azure container relay to the new per-room Cloudflare Durable Object relay at `wss://couch-kit-relay.faluciano.workers.dev`.

## Why

The container relay was pinned to a single replica (in-memory rooms can't span two), died on every deploy, and cost credits to sit idle. One Durable Object per room removes all three, and the free tier covers this workload with orders of magnitude to spare.

Measured connect times:

| | |
|---|---|
| Cloudflare, warm | **61–63 ms** |
| Cloudflare, brand-new room | **472 ms** |
| Azure, warm | 251–306 ms |
| Azure, cold (when scaled to zero) | ~23,000 ms |

## Changes

- `@couch-kit/client` → **^0.10.0**, `@couch-kit/display` → **^0.2.0**
- Relay URL fallbacks repointed in both apps

The SDK bump is **required**, not cosmetic: a Durable Object has to be addressed before any frame is read, so the new relay rejects a bare connection with "Missing or invalid room code". The 0.10/0.2 SDKs put the room in the URL (`<relayUrl>/r/<roomId>`); older versions connect to the bare URL and would fail.

## Verification

Verified locally against the live Cloudflare relay before pushing — see the commit message for this game's specific run.

Azure stays live until all three games are merged and confirmed, then it gets decommissioned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)