### PR TITLE
feat(display): let the relay assign the room code

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@couch-kit/core": "^0.9.3",
-        "@couch-kit/display": "^0.2.0",
+        "@couch-kit/display": "^0.3.0",
         "@my-game/shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -278,11 +278,11 @@
 
     "@couch-kit/devtools": ["@couch-kit/devtools@1.0.0", "", { "peerDependencies": { "@couch-kit/client": "0.9.0", "react": ">=18.0.0" } }, "sha512-whYUy3Ntl0cgYJgD0y5CG+Y5RNJn/JdS6Ta9Rw5yGtlBp5cz71P+Gitjs4Vu7dvx751cePtLWlCbrVadsPU+xw=="],
 
-    "@couch-kit/display": ["@couch-kit/display@0.2.2", "", { "dependencies": { "@couch-kit/client": "0.11.0", "@couch-kit/core": "0.9.3", "@couch-kit/runtime": "0.1.0" } }, "sha512-uYCsaHHJNzyOy0RIl4PfdRkRziQ44KZcXCcGoIt71gwGbsVAWr2+rsE08GiyOTB24T2ldXOCofaD7qU7rvRqkw=="],
+    "@couch-kit/display": ["@couch-kit/display@0.3.0", "", { "dependencies": { "@couch-kit/client": "0.13.0", "@couch-kit/core": "0.9.3", "@couch-kit/runtime": "0.2.0" } }, "sha512-h6gYXsY3NF3aI8lS+NKObfRN7Wz7hMp9Hy0FZUGt3/d8kyGPuJEkHgqfbQJ5tYSrlu7o7g2YLsyYAx5/J/Z5oA=="],
 
     "@couch-kit/host": ["@couch-kit/host@1.7.15", "", { "dependencies": { "@couch-kit/core": "0.9.3", "@couch-kit/runtime": "0.2.0", "buffer": "^6.0.3", "js-sha1": "^0.7.0", "react-native-nitro-http-server": "^1.6.1" }, "peerDependencies": { "expo": ">=51.0.0", "expo-file-system": ">=19.0.0", "expo-network": ">=7.0.0", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-nitro-modules": ">=0.33.0" } }, "sha512-ft39F3NCcRz7JOHY5HbpL8xIM7DftWTmo3bLMeUyBQcMaNRfia6ZRKoOFOpf26I8wJa8RWxG53In35zHvCixyQ=="],
 
-    "@couch-kit/runtime": ["@couch-kit/runtime@0.1.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" } }, "sha512-CG+u0NaeSL23LWzD+E1W2Dw+GT7igHxzrKnUd3NRfcPeq9sYQA/waGYRq31pSzXmOTR3Hmc8zo2qERh0D2TeMw=="],
+    "@couch-kit/runtime": ["@couch-kit/runtime@0.2.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" } }, "sha512-Y4xlygvpFxsJ7t0uWmg0urZz6nqfj4pku+q1/aTJzrgn/sK5i9eKb065EjCYa7DjrtobCPc1gf6pLiWjGHrA2w=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1288,9 +1288,7 @@
 
     "@couch-kit/devtools/@couch-kit/client": ["@couch-kit/client@0.11.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-ft8hKeQKTmt+3r0NCwgcpE1v3Ar4+mpw8Cmq6rdaucOgS4pBNpcSxMZQksEIRAga9q8pgfCunJnytj8VMfuVTg=="],
 
-    "@couch-kit/display/@couch-kit/client": ["@couch-kit/client@0.11.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-ft8hKeQKTmt+3r0NCwgcpE1v3Ar4+mpw8Cmq6rdaucOgS4pBNpcSxMZQksEIRAga9q8pgfCunJnytj8VMfuVTg=="],
-
-    "@couch-kit/host/@couch-kit/runtime": ["@couch-kit/runtime@0.2.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" } }, "sha512-Y4xlygvpFxsJ7t0uWmg0urZz6nqfj4pku+q1/aTJzrgn/sK5i9eKb065EjCYa7DjrtobCPc1gf6pLiWjGHrA2w=="],
+    "@couch-kit/display/@couch-kit/client": ["@couch-kit/client@0.13.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-UtNJjIDQlA2sK9ZTwpOtkOp/FkGPXgNgXjUbzUqgZu5PCB4A9IeEUdiDO6RhZnqkh5GgFpw5GBBZC0FYAbxAUg=="],
 
     "@couch-kit/host/expo-file-system": ["expo-file-system@19.0.23", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA=="],
 

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@couch-kit/core": "^0.9.3",
-    "@couch-kit/display": "^0.2.0",
+    "@couch-kit/display": "^0.3.0",
     "@my-game/shared": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/display/src/App.tsx
+++ b/packages/display/src/App.tsx
@@ -15,34 +15,28 @@ const RELAY_URL =
 // Base URL of the deployed controller. The join link appends `?room=CODE`.
 const CONTROLLER_URL = import.meta.env.VITE_CONTROLLER_URL ?? "";
 
-// Unambiguous room code (no easily-confused characters).
-function makeRoomCode(): string {
-  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-  return Array.from(
-    { length: 4 },
-    () => alphabet[Math.floor(Math.random() * alphabet.length)],
-  ).join("");
-}
-
 export default function App() {
-  const [{ display, roomId }] = useState(() => {
-    const roomId = makeRoomCode();
-    const display = new RelayDisplayHost<GameState, GameAction>({
-      url: RELAY_URL,
-      roomId,
-      reducer: gameReducer,
-      initialState,
-    });
-    return { display, roomId };
-  });
+  // The relay assigns the code — it is the only party that can tell whether a
+  // code is already taken — so it arrives a round trip after connecting.
+  const [roomId, setRoomId] = useState<string | null>(null);
+  const [display] = useState(
+    () =>
+      new RelayDisplayHost<GameState, GameAction>({
+        url: RELAY_URL,
+        onRoomCode: setRoomId,
+        reducer: gameReducer,
+        initialState,
+      }),
+  );
 
   useEffect(() => () => display.stop(), [display]);
 
   const state = useSyncExternalStore(display.subscribe, display.getState);
   const players = Object.values(state.players).filter((p) => p.connected);
-  const joinUrl = CONTROLLER_URL
-    ? `${CONTROLLER_URL}${CONTROLLER_URL.includes("?") ? "&" : "?"}room=${roomId}`
-    : null;
+  const joinUrl =
+    CONTROLLER_URL && roomId
+      ? `${CONTROLLER_URL}${CONTROLLER_URL.includes("?") ? "&" : "?"}room=${roomId}`
+      : null;
 
   return (
     <div
@@ -82,10 +76,14 @@ export default function App() {
           </div>
         )}
         <div style={{ fontSize: "1rem", opacity: 0.7 }}>
-          {joinUrl ? "or enter room code" : "Join with room code"}
+          {!roomId
+            ? "Getting a room code…"
+            : joinUrl
+              ? "or enter room code"
+              : "Join with room code"}
         </div>
         <div style={{ fontSize: "5rem", fontWeight: 800, letterSpacing: "0.5rem" }}>
-          {roomId}
+          {roomId ?? "······"}
         </div>
         {joinUrl ? (
           <a href={joinUrl} style={{ color: "#38bdf8", fontSize: "0.9rem" }}>
@@ -93,7 +91,7 @@ export default function App() {
           </a>
         ) : (
           <div style={{ fontSize: "0.85rem", opacity: 0.6 }}>
-            Open the controller with <code>?room={roomId}</code>
+            Open the controller with <code>?room={roomId ?? "CODE"}</code>
           </div>
         )}
       </div>

--- a/packages/host/src/www-manifest.json
+++ b/packages/host/src/www-manifest.json
@@ -1,6 +1,6 @@
 {
   "files": [
-    "assets/index-a900e4c4.js",
+    "assets/index-65291f5e.js",
     "index.html"
   ]
 }


### PR DESCRIPTION
The display invented its own 4-character code with `Math.random` and hoped it was free. Only the relay knows which codes are live, so a collision surfaced as a dead room whose code was already on the TV.

Deletes the local generator in favour of the relay's ([SDK #158](https://github.com/faluciano/react-native-couch-kit/pull/158)), via `@couch-kit/display` 0.3.0.

## What changes on screen
- Codes are **6 characters** (1.07 billion, vs 1 million)
- The code arrives ~1 round trip after connecting, so the display briefly shows `······`
- The QR is withheld until the code is real — a QR pointing at the wrong room is worse than a brief absence

## Verification
Ran the display against the **production** relay: it minted `KMLMDL`, a phone joined cross-network from the deployed controller, and a buzz took the score 0 → 1 on both screens.

Typecheck and both builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)