### PR TITLE
chore(deps): couch-kit at latest, pinned exactly

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,13 +12,13 @@
       "name": "@my-game/client",
       "version": "1.0.0",
       "dependencies": {
-        "@couch-kit/client": "^0.13.0",
+        "@couch-kit/client": "0.14.0",
         "@my-game/shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
       },
       "devDependencies": {
-        "@couch-kit/devtools": "^1.0.0",
+        "@couch-kit/devtools": "3.0.2",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.0.0",
@@ -30,8 +30,8 @@
       "name": "@my-game/display",
       "version": "1.0.0",
       "dependencies": {
-        "@couch-kit/core": "^0.9.3",
-        "@couch-kit/display": "^0.3.0",
+        "@couch-kit/core": "0.10.0",
+        "@couch-kit/display": "0.4.0",
         "@my-game/shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -49,7 +49,7 @@
       "name": "@my-game/host",
       "version": "1.0.0",
       "dependencies": {
-        "@couch-kit/host": "^1.7.15",
+        "@couch-kit/host": "1.7.16",
         "expo": "~54.0.33",
         "expo-file-system": "~18.0.12",
         "expo-network": "~7.1.1",
@@ -63,7 +63,7 @@
         "react-native-tcp-socket": "^6.2.0",
       },
       "devDependencies": {
-        "@couch-kit/cli": "^0.3.9",
+        "@couch-kit/cli": "0.3.10",
         "@types/react": "~19.1.10",
         "babel-preset-expo": "^54.0.10",
         "typescript": "~5.9.2",
@@ -73,11 +73,11 @@
       "name": "@my-game/shared",
       "version": "1.0.0",
       "devDependencies": {
-        "@couch-kit/core": "^0.9.3",
+        "@couch-kit/core": "0.10.0",
         "typescript": "^5.0.0",
       },
       "peerDependencies": {
-        "@couch-kit/core": "^0.9.3",
+        "@couch-kit/core": "0.10.0",
       },
     },
   },
@@ -270,19 +270,19 @@
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
-    "@couch-kit/cli": ["@couch-kit/cli@0.3.9", "", { "dependencies": { "@couch-kit/core": "0.9.3", "commander": "^15.0.0" }, "bin": { "couch-kit": "dist/index.js" } }, "sha512-LFbLGxE5QIf4TT6xkCJUrIiw7/AVeuFE0QABFBPqdrl1sQZrDaeOme4lCciGytYMqBP3dlE4KEXieqnyZ1LXzA=="],
+    "@couch-kit/cli": ["@couch-kit/cli@0.3.10", "", { "dependencies": { "@couch-kit/core": "0.10.0", "commander": "^15.0.0" }, "bin": { "couch-kit": "dist/index.js" } }, "sha512-+sErIgeDLTePow764zcVgUC6MIJf+x5YLTS9/quCM9xgntg9CjDXSzkAC32hY1DWxmNm4ll1J1P6rTbZlYY7rw=="],
 
-    "@couch-kit/client": ["@couch-kit/client@0.13.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-UtNJjIDQlA2sK9ZTwpOtkOp/FkGPXgNgXjUbzUqgZu5PCB4A9IeEUdiDO6RhZnqkh5GgFpw5GBBZC0FYAbxAUg=="],
+    "@couch-kit/client": ["@couch-kit/client@0.14.0", "", { "dependencies": { "@couch-kit/core": "0.10.0" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-9DWN6bPGT7Eajt0SOhiIQmlIXmNa7ZZtin2gs4ktUkpKgs/+QojULwmyG5/twVznfyDUBq6YhWmnFJh1Dv4H9w=="],
 
-    "@couch-kit/core": ["@couch-kit/core@0.9.3", "", {}, "sha512-8qo0goKd1FkACnWWZCsGHFZWeQqnz3uQgUgKaCoKOXf0AJ1fjF/EJSGAYrHNwPGtKy6Br6CUeJBCzULyQFxFYg=="],
+    "@couch-kit/core": ["@couch-kit/core@0.10.0", "", {}, "sha512-dZ+AUB/kRid3RVocTy3KMEfVn4zY+jT7hk+vBz8tszLonB0Y4oBzrwCYsi9uGAoFB70efWP6j7dhW5qL5yl1Mg=="],
 
-    "@couch-kit/devtools": ["@couch-kit/devtools@1.0.0", "", { "peerDependencies": { "@couch-kit/client": "0.9.0", "react": ">=18.0.0" } }, "sha512-whYUy3Ntl0cgYJgD0y5CG+Y5RNJn/JdS6Ta9Rw5yGtlBp5cz71P+Gitjs4Vu7dvx751cePtLWlCbrVadsPU+xw=="],
+    "@couch-kit/devtools": ["@couch-kit/devtools@3.0.2", "", { "peerDependencies": { "@couch-kit/client": ">=0.9.0 <1.0.0", "react": ">=18.0.0" }, "optionalPeers": ["@couch-kit/client"] }, "sha512-Qx375C4HPA2FtRaMLJe6W9o6Vs7b/uhO0iwZP+CGf0c6YBj6V2ARxXKti9hn9tQR4VsNasS2e/jBOFTnl3alKQ=="],
 
-    "@couch-kit/display": ["@couch-kit/display@0.3.0", "", { "dependencies": { "@couch-kit/client": "0.13.0", "@couch-kit/core": "0.9.3", "@couch-kit/runtime": "0.2.0" } }, "sha512-h6gYXsY3NF3aI8lS+NKObfRN7Wz7hMp9Hy0FZUGt3/d8kyGPuJEkHgqfbQJ5tYSrlu7o7g2YLsyYAx5/J/Z5oA=="],
+    "@couch-kit/display": ["@couch-kit/display@0.4.0", "", { "dependencies": { "@couch-kit/client": "0.14.0", "@couch-kit/core": "0.10.0", "@couch-kit/runtime": "0.3.0" } }, "sha512-GR9EZsRYngaWUxk0kId2GjNIhyT1se6ZE1TEGSsrB54WFPaauf3EJ/gCtfN99PpWRV96vXd/rzIP3HfCXZBFvA=="],
 
-    "@couch-kit/host": ["@couch-kit/host@1.7.15", "", { "dependencies": { "@couch-kit/core": "0.9.3", "@couch-kit/runtime": "0.2.0", "buffer": "^6.0.3", "js-sha1": "^0.7.0", "react-native-nitro-http-server": "^1.6.1" }, "peerDependencies": { "expo": ">=51.0.0", "expo-file-system": ">=19.0.0", "expo-network": ">=7.0.0", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-nitro-modules": ">=0.33.0" } }, "sha512-ft39F3NCcRz7JOHY5HbpL8xIM7DftWTmo3bLMeUyBQcMaNRfia6ZRKoOFOpf26I8wJa8RWxG53In35zHvCixyQ=="],
+    "@couch-kit/host": ["@couch-kit/host@1.7.16", "", { "dependencies": { "@couch-kit/core": "0.10.0", "@couch-kit/runtime": "0.3.0", "buffer": "^6.0.3", "js-sha1": "^0.7.0", "react-native-nitro-http-server": "^1.6.1" }, "peerDependencies": { "expo": ">=51.0.0", "expo-file-system": ">=19.0.0", "expo-network": ">=7.0.0", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-nitro-modules": ">=0.33.0" } }, "sha512-7zTPFM3c9cwJECCRoWcFPxEdC+iYjVJqDtUv/MKK0mJxiyCHiqwP5/ZVVnj9zNkm1zjOop4pxHAq/kysBhurvA=="],
 
-    "@couch-kit/runtime": ["@couch-kit/runtime@0.2.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" } }, "sha512-Y4xlygvpFxsJ7t0uWmg0urZz6nqfj4pku+q1/aTJzrgn/sK5i9eKb065EjCYa7DjrtobCPc1gf6pLiWjGHrA2w=="],
+    "@couch-kit/runtime": ["@couch-kit/runtime@0.3.0", "", { "dependencies": { "@couch-kit/core": "0.10.0" } }, "sha512-zI7UNUKM6czlD1LW73zvT2pYMLigILlnfyffQc+uoe66IHNrDYUTo0zRc8FxmcF36anZlbr2+xvtIu1ZjavGAA=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1285,10 +1285,6 @@
     "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@couch-kit/devtools/@couch-kit/client": ["@couch-kit/client@0.11.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-ft8hKeQKTmt+3r0NCwgcpE1v3Ar4+mpw8Cmq6rdaucOgS4pBNpcSxMZQksEIRAga9q8pgfCunJnytj8VMfuVTg=="],
-
-    "@couch-kit/display/@couch-kit/client": ["@couch-kit/client@0.13.0", "", { "dependencies": { "@couch-kit/core": "0.9.3" }, "peerDependencies": { "react": ">=18.0.0" } }, "sha512-UtNJjIDQlA2sK9ZTwpOtkOp/FkGPXgNgXjUbzUqgZu5PCB4A9IeEUdiDO6RhZnqkh5GgFpw5GBBZC0FYAbxAUg=="],
 
     "@couch-kit/host/expo-file-system": ["expo-file-system@19.0.23", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA=="],
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@couch-kit/client": "^0.13.0",
+    "@couch-kit/client": "0.14.0",
     "@my-game/shared": "workspace:*"
   },
   "devDependencies": {
-    "@couch-kit/devtools": "^1.0.0",
+    "@couch-kit/devtools": "3.0.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -9,8 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@couch-kit/core": "^0.9.3",
-    "@couch-kit/display": "^0.3.0",
+    "@couch-kit/core": "0.10.0",
+    "@couch-kit/display": "0.4.0",
     "@my-game/shared": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -10,7 +10,7 @@
     "prebuild": "expo prebuild"
   },
   "dependencies": {
-    "@couch-kit/host": "^1.7.15",
+    "@couch-kit/host": "1.7.16",
     "expo-file-system": "~18.0.12",
     "expo-network": "~7.1.1",
     "react-native-nitro-modules": "^0.33.9",
@@ -25,7 +25,7 @@
   },
   "private": true,
   "devDependencies": {
-    "@couch-kit/cli": "^0.3.9",
+    "@couch-kit/cli": "0.3.10",
     "@types/react": "~19.1.10",
     "babel-preset-expo": "^54.0.10",
     "typescript": "~5.9.2"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,10 +7,10 @@
     "typecheck": "npx tsc --noEmit"
   },
   "devDependencies": {
-    "@couch-kit/core": "^0.9.3",
+    "@couch-kit/core": "0.10.0",
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@couch-kit/core": "^0.9.3"
+    "@couch-kit/core": "0.10.0"
   }
 }


### PR DESCRIPTION
## Summary

Every `@couch-kit/*` dependency moves to its **latest version, pinned exactly** — no caret ranges. That picks up two relay-traffic cuts from couch-kit#164, with **no code changes needed** here.

| | what it does | effect on buzz |
|---|---|---|
| **client 0.14** | time-sync ping backs off 5s → 30s ceiling | 4 phones idling drop from ~5,760 relay messages/hour to under 1,000 |
| **display 0.4** | projected update ships as one `DATA_MULTI` frame instead of one per player | none — buzz runs no `project`, so its state has always gone out as a single broadcast |

## Why exact pins

This repo was **two SDK releases behind and nothing said so**. On `0.x`, a caret doesn't span minors — `^0.3.0` silently excluded `0.4.0` — so the games quietly sat on old SDKs until someone went looking. An exact version means package.json states what actually runs.

That applies to the peer in `packages/shared` too: its only consumers are workspace packages that pin the same version, so there's nothing for a range to reconcile.

Swept up along the way: `host` 1.7.15 → 1.7.16, `cli` 0.3.9 → 0.3.10, `devtools` 1.0.0 → 3.0.2. The lockfile now resolves exactly one copy of every couch-kit package, with no nested duplicates.

## Verification

- `bun install --frozen-lockfile` clean
- `build:display` + `build:client` green; typecheck green across shared/client/display
- Checked the **artifacts**, not the build status: `DATA_MULTI` in the display bundle, the 30s ceiling (`3e4`) in the client bundle

⚠️ **The RN host path is not covered by any of that.** `host` and `cli` moved a patch version each, and nothing here builds the Android app — worth an `expo run:android` before you cut a host release.

Relay-side support is already deployed (couch-kit#164 merged), so the web side is safe to merge whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)